### PR TITLE
Add config entry for ColmapForVisSat lib dir

### DIFF
--- a/Getting_Started.md
+++ b/Getting_Started.md
@@ -64,8 +64,6 @@
     - Newer versions do not include the required meshlabserver anymore
     - For a list of releases see [here](https://github.com/cnr-isti-vclab/meshlab/releases) 
 
-- Install [](https://lmb.informatik.uni-freiburg.de/people/ummenhof/multiscalefusion/)
-
 - Make [VisSatSatelliteStereo](https://github.com/Kai-46/VisSatSatelliteStereo) and ```SatelliteSurfaceReconstruction``` available to your python interpreter
     - Option 1: Add `VisSatSatelliteStereo` and `SatelliteSurfaceReconstruction` to the python path
         - Add `ssr` (in the `SatelliteSurfaceReconstruction` directory)

--- a/Getting_Started.md
+++ b/Getting_Started.md
@@ -60,7 +60,11 @@
     - Follow the [installation instructions of MVS-Texturing](https://github.com/nmoehrle/mvs-texturing)
    
 - Install [Meshlab](https://github.com/cnr-isti-vclab/meshlab) 
+    - Make sure to install [Meshlab-2020.09](https://github.com/cnr-isti-vclab/meshlab/releases/tag/Meshlab-2020.09) or older
+    - Newer versions do not include the required meshlabserver anymore
     - For a list of releases see [here](https://github.com/cnr-isti-vclab/meshlab/releases) 
+
+- Install [](https://lmb.informatik.uni-freiburg.de/people/ummenhof/multiscalefusion/)
 
 - Make [VisSatSatelliteStereo](https://github.com/Kai-46/VisSatSatelliteStereo) and ```SatelliteSurfaceReconstruction``` available to your python interpreter
     - Option 1: Add `VisSatSatelliteStereo` and `SatelliteSurfaceReconstruction` to the python path

--- a/ssr/config/ssr_config.py
+++ b/ssr/config/ssr_config.py
@@ -1,12 +1,15 @@
 import toml
 from pydantic import BaseModel
 from typing import List, Union
+import os
+from ssr.utility.logging_extension import logger
 
 _config = None
 
 
 class SSRConfig(BaseModel):
     colmap_vissat_exe_fp: str
+    colmap_vissat_lib_dp: str
     texrecon_apps_dp: str
     meshlab_server_fp: str
     meshlab_temp_dp: str
@@ -58,3 +61,14 @@ class SSRConfig(BaseModel):
     def get_from_file(cls, toml_ifp):
         config_dict = toml.load(toml_ifp)
         return cls(**config_dict)
+
+    def check_paths_for_potential_errors(self):
+        attrs = vars(self)
+        for name in attrs:
+            if name.endswith("_dp"):
+                if not os.path.isdir(attrs[name]):
+                    logger.vinfo("The following config entry may not have been set correctly", attrs[name])
+            if name.endswith("_fp"):
+                if not os.path.isfile(attrs[name]):
+                    logger.vinfo("The following config entry may not have been set correctly", attrs[name])
+

--- a/ssr/configs/pipeline_template.toml
+++ b/ssr/configs/pipeline_template.toml
@@ -9,6 +9,9 @@
 
 # === VisSat ===
 colmap_vissat_exe_fp = "/path/to/ColmapForVisSat/build/src/exe/colmap"
+# VisSat assumes its libraries are in the 'build/__install__/lib' directory
+# If you have build VisSat differently and the path differs, you can overwrite it below
+colmap_vissat_lib_dp = "/path/to/ColmapForVisSat/build/__install__/lib"
 
 # === MVS, Mesh and Surface Reconstruction Libraries  ===
 mve_apps_dp = "/path/to/mve/mve/apps"

--- a/ssr/run_pipeline.py
+++ b/ssr/run_pipeline.py
@@ -28,7 +28,9 @@ def create_config_from_template(config_template_ifp, config_fp):
 
     if not os.path.isfile(config_fp):
         copyfile(config_template_ifp, config_fp)
-    return SSRConfig.get_from_file(config_fp)
+    ssr_config = SSRConfig.get_from_file(config_fp)
+    ssr_config.check_paths_for_potential_errors()
+    return ssr_config
 
 
 if __name__ == "__main__":

--- a/ssr/sfm_mvs_rec/vissat_pipeline.py
+++ b/ssr/sfm_mvs_rec/vissat_pipeline.py
@@ -15,6 +15,15 @@ class VisSatPipeline:
         self.colmap_vissat_exe_fp = colmap_vissat_exe_fp
         assert os.path.isfile(colmap_vissat_exe_fp)
         self.colmap_vissat_exe_dp = os.path.dirname(colmap_vissat_exe_fp)
+        self.colmap_vissat_lib_dp = self.ssr_config.colmap_vissat_lib_dp
+
+        # if the path is not set correctly, try to guess the location of the lib folder
+        if not os.path.isdir(self.colmap_vissat_lib_dp):
+            split = os.path.normpath(self.colmap_vissat_exe_dp).split(os.path.sep)
+            if "build" in split:
+                idx_build = split.index("build") + 1
+                if len(split) > idx_build:
+                    self.colmap_vissat_lib_dp = os.path.join(os.path.sep, *split[:idx_build], "__install__", "lib")
 
     def run(self, reconstruct_sfm_mvs):
         dataset_dp = self.ssr_config.satellite_image_pan_dp
@@ -42,6 +51,8 @@ class VisSatPipeline:
 
             assert os.path.isdir(self.colmap_vissat_exe_dp)
             os.environ["PATH"] += os.pathsep + self.colmap_vissat_exe_dp
+            assert os.path.isdir(self.colmap_vissat_lib_dp)
+            os.environ["LD_LIBRARY_PATH"] = self.colmap_vissat_lib_dp
 
             # see https://github.com/Kai-46/VisSatSatelliteStereo/blob/master/stereo_pipeline.py
             from stereo_pipeline import StereoPipeline as VisSatStereoPipeline


### PR DESCRIPTION
- set the path to the lib dir of ColmapForVisSat as env var to fix missing libraries error
- allow user to overwrite the path in the config
- if it is not set, try to guess the lib path on where it should be
- check config paths at beginning of pipeline execution for possible errors (only warning)